### PR TITLE
[#85] Edit Duplicate Person error message in EditCommand 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -48,7 +48,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in Class-ify.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;


### PR DESCRIPTION
Made minor change to Duplicate Person error message in EditCommand.
Fixes part of #85 