### PR TITLE
[UI] Improve UI layout and scaling

### DIFF
--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -5,7 +5,7 @@
 
 .list-cell:empty {
     /* Empty cells will not have alternating colours */
-    -fx-background: #383838;
+    -fx-background: #0D0630;
 }
 
 .tag-selector {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -7,6 +7,7 @@
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
@@ -32,24 +33,26 @@
           </Menu>
         </MenuBar>
 
+        <HBox styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+          <VBox fx:id="personList" alignment="CENTER_LEFT" minWidth="400" prefWidth="400" styleClass="pane-with-border" HBox.hgrow="ALWAYS">
+            <padding>
+              <Insets bottom="10" left="10" right="10" top="10" />
+            </padding>
+            <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+          </VBox>
+
+          <StackPane fx:id="resultDisplayPlaceholder" minWidth="200" prefWidth="200" styleClass="pane-with-border" HBox.hgrow="ALWAYS">
+            <padding>
+              <Insets bottom="5" left="10" right="10" top="5" />
+            </padding>
+          </StackPane>
+        </HBox>
+
         <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER">
           <padding>
             <Insets bottom="5" left="10" right="10" top="5" />
           </padding>
         </StackPane>
-
-        <StackPane fx:id="resultDisplayPlaceholder" maxHeight="100" minHeight="100" prefHeight="100" styleClass="pane-with-border" VBox.vgrow="NEVER">
-          <padding>
-            <Insets bottom="5" left="10" right="10" top="5" />
-          </padding>
-        </StackPane>
-
-        <VBox fx:id="personList" alignment="CENTER" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets bottom="10" left="10" right="10" top="10" />
-          </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
-        </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane fx:id="placeHolder" styleClass="result-display" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" />
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true"/>
 </StackPane>


### PR DESCRIPTION
### Follow up from #165 
<img width="909" alt="Screenshot 2022-10-26 at 1 03 49 PM" src="https://user-images.githubusercontent.com/70556073/197939379-fd2557d4-3fdf-4d8d-b2a3-5c6160c8330d.png">

**Changes:**
- Result display box shifted to the right of the student list panel
- Command box shifted to the bottom
- Result display box wraps text for better display of feedback to user