### PR TITLE
[Enhancement] Update DeleteCommandParser to use ArgumentMultimap

### DIFF
--- a/src/main/java/seedu/classify/commons/core/Messages.java
+++ b/src/main/java/seedu/classify/commons/core/Messages.java
@@ -13,4 +13,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_STUDENT_NAME = "The student name provided does not exist!";
     public static final String MESSAGE_PERSONS_LISTED_IN_CLASS = "There are %1$d students in this class!";
     public static final String MESSAGE_SINGLE_PERSON_LISTED_IN_CLASS = "There is %1$d student in this class!";
+    public static final String MESSAGE_DELETE_COMMAND_DOUBLE_INPUT = "Name and ID inputs detected. "
+            + "Please specify either name or ID only.";
 }

--- a/src/main/java/seedu/classify/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/classify/logic/parser/DeleteCommandParser.java
@@ -1,5 +1,8 @@
 package seedu.classify.logic.parser;
 
+import static seedu.classify.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.classify.logic.parser.CliSyntax.PREFIX_STUDENT_NAME;
+
 import seedu.classify.commons.core.Messages;
 import seedu.classify.logic.commands.DeleteCommand;
 import seedu.classify.logic.parser.exceptions.ParseException;
@@ -19,21 +22,28 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        if (args.startsWith(" id/")) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_STUDENT_NAME, PREFIX_ID);
+
+        boolean isNamePresent = argMultimap.getValue(PREFIX_STUDENT_NAME).isPresent();
+        boolean isIdPresent = argMultimap.getValue(PREFIX_ID).isPresent();
+
+        if (isNamePresent && isIdPresent) {
+            throw new ParseException(String.format(Messages.MESSAGE_DELETE_COMMAND_DOUBLE_INPUT));
+        } else if (isNamePresent) {
             try {
-                Id id = ParserUtil.parseId(args.substring(4));
-                return new DeleteCommand(id, new IdPredicate(id));
-            } catch (ParseException idPE) {
-                throw new ParseException(
-                        String.format(Messages.MESSAGE_INVALID_STUDENT_ID, DeleteCommand.MESSAGE_USAGE), idPE);
-            }
-        } else if (args.startsWith(" nm/")) {
-            try {
-                Name name = ParserUtil.parseName(args.substring(4));
+                Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_STUDENT_NAME).get());
                 return new DeleteCommand(name, new NamePredicate(name));
             } catch (ParseException namePE) {
                 throw new ParseException(
                         String.format(Messages.MESSAGE_INVALID_STUDENT_NAME, DeleteCommand.MESSAGE_USAGE), namePE);
+            }
+        } else if (isIdPresent) {
+            try {
+                Id id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
+                return new DeleteCommand(id, new IdPredicate(id));
+            } catch (ParseException idPE) {
+                throw new ParseException(
+                        String.format(Messages.MESSAGE_INVALID_STUDENT_ID, DeleteCommand.MESSAGE_USAGE), idPE);
             }
         } else {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,


### PR DESCRIPTION
## Changes
- `DeleteCommandParser` now uses `ArgumentMultimap` to check for student name and student ID inputs.
- If both student name and student ID are provided in the arguments, there will be an error.
- If multiple student names or student IDs are provided in the arguments, the latest one will be taken.
Example: In the case of `delete id/123A id/456B`, the equivalent of `delete id/456B` will be executed.
