### PR TITLE
[User Guide] Add clarification and emphasis in AddStudent section

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -175,7 +175,7 @@ Edits the respective details of an existing student.
 * Existing values will be updated to the new input values.
 * Refer to the complete list of tags for each field under [addStudent command](#411-adding-a-new-student-record--addstudent).
 
-Format: `edit INDEX [nm/STUDENT-NAME] [id/ID] [exam/NAME SCORE] [pn/PARENT-NAME] ...`
+Format: `edit INDEX [nm/STUDENT-NAME] [id/ID] [exam/EXAM-NAME SCORE] [pn/PARENT-NAME] ...`
 
 Examples:
 *  `edit 1 exam/CA2 70 exam/SA1 60` Adds or updates the CA2 and SA1 exam grades of the 1st student to be `70` and `60` respectively.
@@ -249,11 +249,11 @@ is set to "ON", only students whose score for the specified exam falls below the
 
 The list of students displayed will be arranged in ascending grades, using the grade for the specified exam.
 
-Format: `viewStats class/CLASS exam/EXAM filter/FILTER`
+Format: `viewStats class/CLASS exam/EXAM-NAME filter/FILTER`
 
 * Class name can only contain alphanumeric characters.
 * Class name is case-insensitive.
-* Exam name should be either "CA1", "CA2", "SA1" or "SA2".
+* Exam name should be either _CA1_, _CA2_, _SA1_ or _SA2_.
 * Exam name is case-insensitive
 * Filter is either "ON" or "OFF", and is case-insensitive.
 
@@ -301,19 +301,19 @@ Click <a href="#top">here</a> to return to the top.
 
 ## 6. **Command summary**
 
-|              Action               | Format                                                                                                        | Example                                                                          |  
-|:---------------------------------:|:--------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------|
-|     Add a new student record      | `addStudent nm/STUDENT-NAME id/ID class/CLASS [exam/EXAM SCORE] [pn/PARENT-NAME] [hp/PHONE-NUMBER] [e/EMAIL]` | _addStudent nm/Alex Yeoh id/123A class/1A pn/Bernice Yu hp/99272758 exam/CA1 90_ |
-|     View all student records      | `viewAll`                                                                                                     | _viewAll_                                                                        |
-| View student records from a class | `viewClass CLASS`                                                                                             | _viewClass 1A_                                                                   |
-|       Edit a student record       | `edit INDEX [nm/STUDENT-NAME] [id/ID] [exam/NAME SCORE] [pn/PARENT-NAME] ...`                                 | _edit 1 nm/Alexander Yeoh_                                                       |
-|      Delete a student record      | `delete nm/STUDENT-NAME` or `delete id/ID`                                                                    | _delete nm/Jonathan Tan or delete id/123A_                                       |
-|       Find a student record       | `find nm/STUDENT-NAME` or `find id/ID`                                                                        | _find nm/Jonathan Tan or find id/123A_                                           |
-| View exam statistics for a class  | `viewStats class/CLASS exam/EXAM filter/FILTER`                                                               | _viewStats class/1A exam/CA1 filter/on_                                          |
-|            Toggle view            | `toggleView`                                                                                                  | _toggleView_                                                                     |
-|     Clear all student records     | `clear`                                                                                                       | _clear_                                                                          |
-|    View command summary table     | `help`                                                                                                        | _help_                                                                           |
-|         Exit application          | `exit`                                                                                                        | _exit_                                                                           |
+|              Action               | Format                                                                                                             | Example                                                                          |  
+|:---------------------------------:|:-------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------|
+|     Add a new student record      | `addStudent nm/STUDENT-NAME id/ID class/CLASS [exam/EXAM-NAME SCORE] [pn/PARENT-NAME] [hp/PHONE-NUMBER] [e/EMAIL]` | _addStudent nm/Alex Yeoh id/123A class/1A pn/Bernice Yu hp/99272758 exam/CA1 90_ |
+|     View all student records      | `viewAll`                                                                                                          | _viewAll_                                                                        |
+| View student records from a class | `viewClass CLASS`                                                                                                  | _viewClass 1A_                                                                   |
+|       Edit a student record       | `edit INDEX [nm/STUDENT-NAME] [id/ID] [exam/EXAM-NAME SCORE] [pn/PARENT-NAME] ...`                                 | _edit 1 nm/Alexander Yeoh_                                                       |
+|      Delete a student record      | `delete nm/STUDENT-NAME` or `delete id/ID`                                                                         | _delete nm/Jonathan Tan or delete id/123A_                                       |
+|       Find a student record       | `find nm/STUDENT-NAME` or `find id/ID`                                                                             | _find nm/Jonathan Tan or find id/123A_                                           |
+| View exam statistics for a class  | `viewStats class/CLASS exam/EXAM-NAME filter/FILTER`                                                               | _viewStats class/1A exam/CA1 filter/on_                                          |
+|            Toggle view            | `toggleView`                                                                                                       | _toggleView_                                                                     |
+|     Clear all student records     | `clear`                                                                                                            | _clear_                                                                          |
+|    View command summary table     | `help`                                                                                                             | _help_                                                                           |
+|         Exit application          | `exit`                                                                                                             | _exit_                                                                           |
 
 Click <a href="#top">here</a> to return to the top.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -120,29 +120,26 @@ will delete all data stored locally and this action is irreversible. You will lo
 
 #### 4.1.1 Adding a new student record : `addStudent`
 
-Creates a new student record with the following details:
+Creates a new student record with the following parameters:
 
-* **Name of Student** `nm/`
-* **Student's ID (last 4 digits of NRIC)** `id/`
-  * ID should only contain 3 digits followed by 1 character.
-* **Student's Class** `class/`
-  * Similar to names, class name should only contain alphanumeric characters and spaces.
-* Exam Grades for CA1, CA2, SA1, and SA2 `exam/`
-* Name of Parent `pn/`
-* Mobile Number of Parent `hp/`
-  * Phone numbers should only contain numbers, and it should be at least 3 digits long. 
-* Email Address of Parent `e/`
-  * Email address should follow standard convention format local-part@domain.
+| **Paramter**        | **Prefix** | **Compulsory** | **Description**                                                                                                                                                                                                                                                                    |
+|---------------------|------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Name**            | `nm/`      | Yes            | Student's name should be alphanumeric, consisting of both letters and numbers only. As student names are treated as unique, it is recommended to use the full name of the student.                                                                                                 |
+| **ID**              | `id/`      | Yes            | Student's id should contain 3 digits followed by 1 character (e.g. `123A`). Do note that ids are unique, hence no two students should have the same ids.                                                                                                                           |
+| **Class**           | `class/`   | Yes            | Class name should be alphanumeric, consisting of both letters and numbers only.                                                                                                                                                                                                    |
+| **Exam**            | `exam/`    | No             | Exams should follow the format exam name followed by score (e.g. `CA1 90`). Current accepted exam names are _CA1_, _CA2_, _SA1_ and _SA2_. Future versions may allow custom exam or gradable items to be created. In addition, scores should be an integer value between 0 to 100. |
+| **Parent's Name**   | `pn/`      | No             | Name of student's parent. Similar to the student's name, the parent's name should be alphanumeric also.                                                                                                                                                                            |
+| **Parent's Mobile** | `hp/`      | No             | Mobile number of student's parent. It should only contain numbers, and it should be at least 3 digits long. Entries with country code can be prefixed without the plus sign.                                                                                                       |
+| **Parent's Email**  | `e/`       | No             | Email address of student's parent should follow standard convention format _local-part@domain_.                                                                                                                                                                                    |
 
-Format: `addStudent nm/STUDENT-NAME id/ID class/CLASS [exam/NAME SCORE] [pn/PARENT-NAME] [hp/PHONE-NUMBER] [e/EMAIL]`
+Format: `addStudent nm/STUDENT-NAME id/ID class/CLASS [exam/EXAM-NAME SCORE] [pn/PARENT-NAME] [hp/PHONE-NUMBER] [e/EMAIL]`
 
 <div markdown="span" class="alert alert-primary">:bulb:
-**Tip #1:** All **bolded** fields are compulsory. Optional fields can be added later using the [edit command](#414-editing-a-student-record--edit).
+**Tip:** Optional fields can be added later using the [edit command](#414-editing-a-student-record--edit).
 </div>
 
-<div markdown="span" class="alert alert-primary">:bulb:
-**Tip #2:** To add exam grades, specify the tag `exam/` followed by an exam name (CA1, CA2, SA1, or SA2) and score (a number from 0 to 100). Multiple exams can be added in a single line.<br>
-Example: `exam/CA1 50 exam/SA1 60 exam/CA1 80` will add grades 80 for CA1 and 60 for SA1. Notice the first score for CA1 is overridden by the second score for CA1.
+<div markdown="span" class="alert alert-info">:information_source:
+**Note:** Multiple exams can be added in a single line. For example, `exam/CA1 50 exam/SA1 60 exam/CA1 80` will add grades 80 for CA1 and 60 for SA1. Notice the first score for CA1 is overridden by the second score for CA1.
 </div>
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -75,7 +75,7 @@ Tips are useful bits of information that will help you have a better experience 
 
 <div markdown="span" class="alert alert-primary">:bulb:
 **Tip:** Tips are useful!
-</div><br>
+</div><br/>
 
 **Notes**
 
@@ -83,7 +83,7 @@ Notes are here to provide you with extra information that you may find helpful w
 
 <div markdown="span" class="alert alert-info">:information_source:
 **Note:** Take notes when you see this icon!
-</div><br>
+</div><br/>
 
 **Caution**
 
@@ -93,7 +93,7 @@ will delete all data stored locally and this action is irreversible. You will lo
 <div markdown="span" class="alert alert-warning">
 :exclamation: Stop and read carefully when you see this!
 </div>
-<br>
+<br/>
 <div markdown="block" class="alert alert-info">:information_source:
 **Notes on the Command Format:** <br>
 
@@ -122,7 +122,7 @@ will delete all data stored locally and this action is irreversible. You will lo
 
 Creates a new student record with the following parameters:
 
-| **Paramter**        | **Prefix** | **Compulsory** | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Parameter**       | **Prefix** | **Compulsory** | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                             |
 |---------------------|------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Name**            | `nm/`      | Yes            | Student's name should be **alphanumeric**, consisting of both letters and numbers only. As student names are treated as unique, we recommend you to use the full name of the student.<br/><br/>For optimal viewing, the length of the name should be **at most 17 characters**. Any longer would result in the name being cut off from the application display, though it will not affect the actual record being saved in the application. |
 | **ID**              | `id/`      | Yes            | Student's id should contain **3 digits followed by 1 character** (e.g. `123A`). Do note that ids are unique, hence no two students should have the same ids.                                                                                                                                                                                                                                                                                |
@@ -133,6 +133,15 @@ Creates a new student record with the following parameters:
 | **Parent's Email**  | `e/`       | No             | Email address of student's parent should follow standard convention format _local-part@domain_.                                                                                                                                                                                                                                                                                                                                             |
 
 Format: `addStudent nm/STUDENT-NAME id/ID class/CLASS [exam/EXAM-NAME SCORE] [pn/PARENT-NAME] [hp/PHONE-NUMBER] [e/EMAIL]`
+
+Examples:
+* `addStudent nm/Peter Tan id/452B class/1F`
+* `addStudent nm/Alex Yeoh id/123A class/2B exam/CA1 60 exam/CA2 70`
+* `addStudent nm/John Doe id/928C class/1A pn/Bob Doe hp/98765432 e/bobdoe@gmail.com exam/CA1 50`
+
+<div markdown="span" class="alert alert-info">:information_source:
+**Note:** All fields are capitalised when saved into the application. Therefore, parameters like `nm/john` and `nm/JoHn` are treated as _JOHN_ by default.
+</div>
 
 <div markdown="span" class="alert alert-primary">:bulb:
 **Tip:** Optional fields can be added later using the [edit command](#414-editing-a-student-record--edit).
@@ -145,11 +154,6 @@ Format: `addStudent nm/STUDENT-NAME id/ID class/CLASS [exam/EXAM-NAME SCORE] [pn
 <div markdown="span" class="alert alert-warning">:exclamation:
 **Caution:** If you are receiving an invalid command message, do check to ensure that you are using the correct prefix for the intended parameter.
 </div>
-
-Examples:
-* `addStudent nm/Peter Tan id/452B class/1F`
-* `addStudent nm/Alex Yeoh id/123A class/2B exam/CA1 60 exam/CA2 70`
-* `addStudent nm/John Doe id/928C class/1A pn/Bob Doe hp/98765432 e/bobdoe@gmail.com exam/CA1 50`
 
 #### 4.1.2 Clearing all student records : `clear`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -114,7 +114,7 @@ will delete all data stored locally and this action is irreversible. You will lo
   * Optional parameters are indicated by square brackets `[]`. <br>
   e.g. For the `addStudent` command, the command format is `addStudent nm/STUDENT-NAME id/ID class/CLASS [pn/PARENT-NAME] [hp/PHONE-NUMBER]...`<br>
   `[pn/PARENT-NAME]` and `[hp/PHONE-NUMBER]` refer to optional parameters that can be supplied by the user.
-</div><br>
+</div><br/>
 
 ### 4.1 Managing student records
 
@@ -122,15 +122,15 @@ will delete all data stored locally and this action is irreversible. You will lo
 
 Creates a new student record with the following parameters:
 
-| **Paramter**        | **Prefix** | **Compulsory** | **Description**                                                                                                                                                                                                                                                                    |
-|---------------------|------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Name**            | `nm/`      | Yes            | Student's name should be alphanumeric, consisting of both letters and numbers only. As student names are treated as unique, it is recommended to use the full name of the student.                                                                                                 |
-| **ID**              | `id/`      | Yes            | Student's id should contain 3 digits followed by 1 character (e.g. `123A`). Do note that ids are unique, hence no two students should have the same ids.                                                                                                                           |
-| **Class**           | `class/`   | Yes            | Class name should be alphanumeric, consisting of both letters and numbers only.                                                                                                                                                                                                    |
-| **Exam**            | `exam/`    | No             | Exams should follow the format exam name followed by score (e.g. `CA1 90`). Current accepted exam names are _CA1_, _CA2_, _SA1_ and _SA2_. Future versions may allow custom exam or gradable items to be created. In addition, scores should be an integer value between 0 to 100. |
-| **Parent's Name**   | `pn/`      | No             | Name of student's parent. Similar to the student's name, the parent's name should be alphanumeric also.                                                                                                                                                                            |
-| **Parent's Mobile** | `hp/`      | No             | Mobile number of student's parent. It should only contain numbers, and it should be at least 3 digits long. Entries with country code can be prefixed without the plus sign.                                                                                                       |
-| **Parent's Email**  | `e/`       | No             | Email address of student's parent should follow standard convention format _local-part@domain_.                                                                                                                                                                                    |
+| **Paramter**        | **Prefix** | **Compulsory** | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                             |
+|---------------------|------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Name**            | `nm/`      | Yes            | Student's name should be **alphanumeric**, consisting of both letters and numbers only. As student names are treated as unique, we recommend you to use the full name of the student.<br/><br/>For optimal viewing, the length of the name should be **at most 17 characters**. Any longer would result in the name being cut off from the application display, though it will not affect the actual record being saved in the application. |
+| **ID**              | `id/`      | Yes            | Student's id should contain **3 digits followed by 1 character** (e.g. `123A`). Do note that ids are unique, hence no two students should have the same ids.                                                                                                                                                                                                                                                                                |
+| **Class**           | `class/`   | Yes            | Class name should be **alphanumeric**, consisting of both letters and numbers only.                                                                                                                                                                                                                                                                                                                                                         |
+| **Exam**            | `exam/`    | No             | Exams should follow the format **exam name followed by score** (e.g. `CA1 90`). Current accepted exam names are _CA1_, _CA2_, _SA1_ and _SA2_. Future versions may allow custom exam or gradable items to be created.<br/><br/>In addition, scores should be an integer value between 0 to 100. Partial scores are currently not accepted.                                                                                                  |
+| **Parent's Name**   | `pn/`      | No             | Name of student's parent. Similar to the student's name, the parent's name should be **alphanumeric** also.                                                                                                                                                                                                                                                                                                                                 |
+| **Parent's Mobile** | `hp/`      | No             | Mobile number of student's parent. It should only contain numbers, and it should be **at least 3 digits long**.<br/><br/>Entries with country code can be prefixed without the plus sign. For example, `+65 91234567` can be entered as `6591234567` instead.                                                                                                                                                                               |
+| **Parent's Email**  | `e/`       | No             | Email address of student's parent should follow standard convention format _local-part@domain_.                                                                                                                                                                                                                                                                                                                                             |
 
 Format: `addStudent nm/STUDENT-NAME id/ID class/CLASS [exam/EXAM-NAME SCORE] [pn/PARENT-NAME] [hp/PHONE-NUMBER] [e/EMAIL]`
 
@@ -138,8 +138,12 @@ Format: `addStudent nm/STUDENT-NAME id/ID class/CLASS [exam/EXAM-NAME SCORE] [pn
 **Tip:** Optional fields can be added later using the [edit command](#414-editing-a-student-record--edit).
 </div>
 
-<div markdown="span" class="alert alert-info">:information_source:
-**Note:** Multiple exams can be added in a single line. For example, `exam/CA1 50 exam/SA1 60 exam/CA1 80` will add grades 80 for CA1 and 60 for SA1. Notice the first score for CA1 is overridden by the second score for CA1.
+<div markdown="span" class="alert alert-primary">:bulb:
+**Tip:** Multiple exams can be added in a single line. For example, `exam/CA1 50 exam/SA1 60 exam/CA1 80` will add grades 80 for CA1 and 60 for SA1. Notice the first score for CA1 is overridden by the second score for CA1.
+</div>
+
+<div markdown="span" class="alert alert-warning">:exclamation:
+**Caution:** If you are receiving an invalid command message, do check to ensure that you are using the correct prefix for the intended parameter.
 </div>
 
 Examples:


### PR DESCRIPTION
Fixes #202 #204 #208 #214 #218 

### Changes
- Add the following table for easier viewing of the student fields

| **Parameter**       | **Prefix** | **Compulsory** | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                             |
|---------------------|------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| **Name**            | `nm/`      | Yes            | Student's name should be **alphanumeric**, consisting of both letters and numbers only. As student names are treated as unique, we recommend you to use the full name of the student.<br/><br/>For optimal viewing, the length of the name should be **at most 17 characters**. Any longer would result in the name being cut off from the application display, though it will not affect the actual record being saved in the application. |
| **ID**              | `id/`      | Yes            | Student's id should contain **3 digits followed by 1 character** (e.g. `123A`). Do note that ids are unique, hence no two students should have the same ids.                                                                                                                                                                                                                                                                                |
| **Class**           | `class/`   | Yes            | Class name should be **alphanumeric**, consisting of both letters and numbers only.                                                                                                                                                                                                                                                                                                                                                         |
| **Exam**            | `exam/`    | No             | Exams should follow the format **exam name followed by score** (e.g. `CA1 90`). Current accepted exam names are _CA1_, _CA2_, _SA1_ and _SA2_. Future versions may allow custom exam or gradable items to be created.<br/><br/>In addition, scores should be an integer value between 0 to 100. Partial scores are currently not accepted.                                                                                                  |
| **Parent's Name**   | `pn/`      | No             | Name of student's parent. Similar to the student's name, the parent's name should be **alphanumeric** also.                                                                                                                                                                                                                                                                                                                                 |
| **Parent's Mobile** | `hp/`      | No             | Mobile number of student's parent. It should only contain numbers, and it should be **at least 3 digits long**.<br/><br/>Entries with country code can be prefixed without the plus sign. For example, `+65 91234567` can be entered as `6591234567` instead.                                                                                                                                                                               |
| **Parent's Email**  | `e/`       | No             | Email address of student's parent should follow standard convention format _local-part@domain_.                                                                                                                                                                                                                                                                                                                                             |

- Standardise exam name to EXAM-NAME
- Specify that no partial marks are allowed
- Add caution for users to be careful when entering the prefixes