### PR TITLE
[Documentation][User Guide] Change Command Format description in User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -15,7 +15,7 @@ title: User Guide
 
 ### 1.1 What is Class-ify?
 
-Class-ify is a **class management application** built specially for **Ministry of Education (MOE) teachers** to 
+Class-ify is a **class management application** built specially for **Singapore Ministry of Education (MOE) teachers** to 
 **monitor their student's academic progress easily**. Teachers can **generate exam statistics** for each class, 
 and Class-ify quickly **flags out students** who require more support for contacting.
 
@@ -71,7 +71,7 @@ Before you begin reading, here are some special notations to help you along the 
 
 **Tips**
 
-Tips are useful bits of information that will help you have a better experience with Class-ify.
+Tips are useful suggestions that will help you have a better experience with Class-ify.
 
 <div markdown="span" class="alert alert-primary">:bulb:
 **Tip:** Tips are useful!
@@ -79,10 +79,10 @@ Tips are useful bits of information that will help you have a better experience 
 
 **Notes**
 
-Notes are here to provide you with extra information that you may find helpful when using Class-ify.
+Notes are important information that you should pay attention to when using Class-ify.
 
 <div markdown="span" class="alert alert-info">:information_source:
-**Note:** Take notes when you see this icon!
+**Note:** Take note when you see this icon!
 </div><br>
 
 **Caution**
@@ -94,8 +94,10 @@ will delete all data stored locally and this action is irreversible. You will lo
 :exclamation: Stop and read carefully when you see this!
 </div>
 <br>
+
+### 4.1 Notes on the Command Format
 <div markdown="block" class="alert alert-info">:information_source:
-**Notes on the Command Format:** <br>
+**Note:** <br>
 
 * **Command Words**
   * Command words and prefixes are case-sensitive. <br>
@@ -116,9 +118,9 @@ will delete all data stored locally and this action is irreversible. You will lo
   `[pn/PARENT-NAME]` and `[hp/PHONE-NUMBER]` refer to optional parameters that can be supplied by the user.
 </div><br>
 
-### 4.1 Managing student records
+### 4.2 Managing student records
 
-#### 4.1.1 Adding a new student record : `addStudent`
+#### 4.2.1 Adding a new student record : `addStudent`
 
 Creates a new student record with the following details:
 
@@ -150,13 +152,17 @@ Examples:
 * `addStudent nm/Alex Yeoh id/123A class/2B exam/CA1 60 exam/CA2 70`
 * `addStudent nm/John Doe id/928C class/1A pn/Bob Doe hp/98765432 e/bobdoe@gmail.com exam/CA1 50`
 
-#### 4.1.2 Clearing all student records : `clear`
+#### 4.2.2 Clearing all student records : `clear`
 
 Clears all student records from local storage.
 
 Format: `clear`
 
-#### 4.1.3 Deleting a student record : `delete`
+<div markdown="span" class="alert alert-warning">
+:exclamation: **Caution:** This command will delete all data stored locally and this action is irreversible. You will lose your data permanently.!
+</div>
+
+#### 4.2.3 Deleting a student record : `delete`
 
 Deletes an existing student record from the class list, using the student’s name or the student’s ID.
 
@@ -166,13 +172,13 @@ Examples:
 * `delete nm/Jonathan Tan` deletes student record with student name as 'Jonathan Tan'.
 * `delete id/123A` deletes student record with student ID as '123A'.
 
-#### 4.1.4 Editing a student record : `edit`
+#### 4.2.4 Editing a student record : `edit`
 
 Edits the respective details of an existing student.
 
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the current displayed list. The index **must be a positive integer** 1, 2, 3 ...
 * Existing values will be updated to the new input values.
-* Refer to the complete list of tags for each field under [addStudent command](#411-adding-a-new-student-record--addstudent).
+* Refer to the complete list of tags for each field under [addStudent command](#421-adding-a-new-student-record--addstudent).
 
 Format: `edit INDEX [nm/STUDENT-NAME] [id/ID] [exam/NAME SCORE] [pn/PARENT-NAME] ...`
 
@@ -180,7 +186,7 @@ Examples:
 *  `edit 1 exam/CA2 70 exam/SA1 60` Adds or updates the CA2 and SA1 exam grades of the 1st student to be `70` and `60` respectively.
 *  `edit 2 nm/Jacob Teo` Edits the name of the 2nd student to `Jacob Teo`.
 
-### 4.2 Managing display of student records
+### 4.3 Managing display of student records
 
 <div markdown="span" class="alert alert-info">:information_source:
    **Note:**
@@ -188,7 +194,7 @@ Examples:
    Commands related to managing display are not saved upon exiting the application.
 </div>
 
-#### 4.2.1 Finding a student record : `find`
+#### 4.3.1 Finding a student record : `find`
 
 Shows a list of students whose name contains the specified name keywords, or whose Id matches the given Id.
 
@@ -202,7 +208,7 @@ Examples:
 * `find nm/John` returns the record students whose names contain `John`
 * `find nm/john alice` returns the records for the students whose name contains `john` or `alice`.
 
-#### 4.2.2 Toggling view : `toggleView`
+#### 4.3.2 Toggling view : `toggleView`
 
 Toggles the display between showing and hiding the students' parent details. 
 
@@ -220,18 +226,17 @@ Format: `toggleView`
    **Tip:** The default display renders the students' parent details as a reminder that these optional fields exists.   
 </div>
 
-#### 4.2.3 Viewing all student records : `viewAll`
+#### 4.3.3 Viewing all student records : `viewAll`
 
 Shows a list of all student records in Classify.
 
 Format: `viewAll`
 
-#### 4.2.4 Viewing student records from a class : `viewClass`
+#### 4.3.4 Viewing student records from a class : `viewClass`
 
 Shows a list of all students in the specified class.
 
 Format: `viewClass CLASS`
-
 * Class name can only contain alphanumeric characters.
 * Class name is case-insensitive.
 
@@ -239,9 +244,9 @@ Examples:
 * `viewClass 2A` Displays the list of students with the class `2A`.
 * `viewClass Loyalty1` Displays the list of students with the class `LOYALTY1`.
 
-### 4.3 Exam statistics
+### 4.4 Exam statistics
 
-#### 4.3.1 Getting exam statistics: `viewStats`
+#### 4.4.1 Getting exam statistics: `viewStats`
 
 Shows a list of students in the specified class, and displays the mean of the specified exam for that class. If filter 
 is set to "ON", only students whose score for the specified exam falls below the mean will be displayed.
@@ -262,21 +267,21 @@ all the students in the class '4A', arranged in ascending grades for "SA1".
 * `viewStats class/4A exam/sa1 filter/on` Displays the mean obtained by class "4A" for "SA1", as well as the list of 
 students in class "4A" whose grade for "SA1" falls below the mean, arranged in ascending grades for "SA1".
 
-### 4.4 Miscellaneous
+### 4.5 Miscellaneous
 
-#### 4.4.1 Exiting the application : `exit`
+#### 4.5.1 Exiting the application : `exit`
 
 Exits the application.
 
 Format: `exit`
 
-#### 4.4.2 Viewing help : `help`
+#### 4.5.2 Viewing help : `help`
 
 Shows a summary of all commands available.
 
 Format: `help`
 
-#### 4.4.3 Saving the data
+#### 4.5.3 Saving the data
 
 Student records are saved locally after any command that changes the data. There is no need to save manually.
 


### PR DESCRIPTION
**Changes:**
- Made changes to the Tips/Notes description to better describe what they mean.
    - Tips are useful suggestions that will help you have a better experience with Class-ify.
    - Notes are important information that you should pay attention to when using Class-ify.
- Added in caution for clear command
- Added in a new section for the 'Notes on Command Format' under the Features section as it may seem quite weird that the notes about command format come right after the special notations without any distinctions. (We can see if this looks better)
- Added in 'Singapore MOE teachers' for clarity