### PR TITLE
[#216] [FindCommand] Fix error with FindCommand behaviour

### DIFF
--- a/src/main/java/seedu/classify/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/classify/logic/parser/FindCommandParser.java
@@ -28,6 +28,13 @@ public class FindCommandParser implements Parser<FindCommand> {
         ArgumentMultimap argMultiMap = ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_STUDENT_NAME,
                 CliSyntax.PREFIX_ID);
 
+        // Invalid Command if both name and id prefixes are used
+        if (argMultiMap.getValue(CliSyntax.PREFIX_STUDENT_NAME).isPresent()
+                && argMultiMap.getValue(CliSyntax.PREFIX_ID).isPresent()) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
         if (argMultiMap.getValue(CliSyntax.PREFIX_STUDENT_NAME).isPresent()) {
             String[] nameKeywords = argMultiMap.getValue(CliSyntax.PREFIX_STUDENT_NAME).get().split("\\s+");
             return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));

--- a/src/test/java/seedu/classify/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/classify/logic/parser/FindCommandParserTest.java
@@ -19,7 +19,14 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_bothNameAndIdPrefix_throwsParseException() {
+        assertParseFailure(parser, " nm/Alice id/123A",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
fixes #216 

#### Changes:

* FindCommandParser is updated to throw an error when user attempts to search for a student using both the student's name and the student's id, as this was not the intended behaviour of FindCommand, according to the UG.